### PR TITLE
[FIX] Update `sampleUrl` with hosting url as default in hosted documentation

### DIFF
--- a/specs/v0.1.md
+++ b/specs/v0.1.md
@@ -277,7 +277,7 @@ A single parameter field.
 | description   | string   | Project description. It is used as introduction at the beginning of the documentation. |
 | title         | [string] | Browser title. |
 | url           | [string] | Public URL to access the API (prefix URL for an endpoint).<br>Example: `"https://api.github.com/v1"` |
-| sampleUrl     | [string] | Public URL to test the API.<br>Example: `"https://playground.github.com/v1"` |
+| sampleUrl     | [string] | Public URL to test the API. In generated web documentation, sampleUrl is set as hosting URL if none provided. <br>Example: `"https://playground.github.com/v1"` |
 | generator     | [[Generator](#generator-object)] | Provides generator informations. |
 | template      | [[Template](#template-object)]   | Template specific settings. |
 | header        | [[Header](#header-object)]       | Additional content for the top of the documentation. |


### PR DESCRIPTION
Update `sampleUrl` documentation to reflect changes brought by https://github.com/apidoc/apidoc/pull/915

I'm a little unsure how it should be put in since the default is only set in the documentation that is generated for the web version using the template and not set in the generated JSON structure which is used to convert to mark